### PR TITLE
Changes from Forked BDQC Dev Branch

### DIFF
--- a/src/bdqc/scan.py
+++ b/src/bdqc/scan.py
@@ -27,6 +27,7 @@ import time
 import logging
 import io
 import pkg_resources
+import warnings
 
 import bdqc.plugin
 import bdqc.dir
@@ -315,10 +316,16 @@ def _main( args ):
 
 	plugins = []
 	# ...maybe including defaults...
-	if ( args.plugins == None or args.plugins[0] == '+' ) and \
-			os.path.isfile( DEFAULT_PLUGIN_RCFILE ):
-		with open( DEFAULT_PLUGIN_RCFILE ) as fp:
-			plugins.extend( [ l.rstrip() for l in fp.readlines() ] )
+
+	# check if plugins.txt exists in expected path and handle if not
+	plugins_textfile_message= "plugins.txt is missing! Please report and add to {0} manually".format(DEFAULT_PLUGIN_RCFILE)
+	assert(os.path.isfile(DEFAULT_PLUGIN_RCFILE)),  plugins_textfile_message
+
+	if (args.plugins == None or args.plugins[0] == '+') and \
+			os.path.isfile(DEFAULT_PLUGIN_RCFILE):
+		with open(DEFAULT_PLUGIN_RCFILE) as fp:
+			plugins.extend([l.rstrip() for l in fp.readlines()])
+
 	# ...and maybe including additional.
 	if args.plugins:
 		for plugname in args.plugins.split(','):

--- a/src/bdqc/scan.py
+++ b/src/bdqc/scan.py
@@ -26,6 +26,7 @@ import json
 import time
 import logging
 import io
+import pkg_resources
 
 import bdqc.plugin
 import bdqc.dir
@@ -33,7 +34,8 @@ from bdqc.analysis import Matrix
 from bdqc.statpath import selectors
 
 ANALYSIS_EXTENSION = ".bdqc"
-DEFAULT_PLUGIN_RCFILE = os.path.join(os.environ['HOME'],'.bdqc','plugins.txt')
+DATA_PATH = pkg_resources.resource_filename('bdqc', '')
+DEFAULT_PLUGIN_RCFILE = pkg_resources.resource_filename('bdqc', '/plugins.txt')
 _PLUGIN_VERSION = "VERSION"
 _CACHE_VERSION  = "version"
 

--- a/src/c/fopenx.c
+++ b/src/c/fopenx.c
@@ -145,7 +145,7 @@ FILE *fopenx( const char *fname, const char *mode ) {
 		assert( CODEC < CODEC_COUNT );
 		cmd = malloc( FILENAME_MAX+32 );
 		if( cmd ) {
-			sprintf( cmd, "%s %s", _decompress_cmd[CODEC], fname );
+			sprintf( cmd, "%s \"%s\"", _decompress_cmd[CODEC], fname );
 			fp = popen( cmd, "r" );
 			if( NULL == fp ) {
 				fprintf( stderr, "popen( \"%s\", \"r\" ): %s", cmd, strerror(errno) );

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,7 @@ setup(name="bdqc",
 		'bdqc.builtin.filetype',
 		'bdqc.builtin.tabular' ],
 #	package_dir=
-	package_data={'bdqc':['template.html','template.css','render.js']},
+	package_data={'bdqc':['template.html','template.css','render.js', '../data/*.txt']},
 	ext_package='bdqc.builtin', # ...scopes all extensions
 	ext_modules=[
 		Extension('compiled',
@@ -47,7 +47,6 @@ setup(name="bdqc",
 				'c/stats/quicksel.c'
 			 ],
 			 extra_compile_args=['-std=c99'],
-			 define_macros=[("_POSIX_C_SOURCE","200809L"),])],
-	data_files=[('.bdqc',['data/plugins.txt',]),]
+			 define_macros=[("_POSIX_C_SOURCE","200809L"),])]
 	)
 


### PR DESCRIPTION
## Files changed:

- **scan.py:** 
    + Address plugins.txt location retrieval
    + Address occurrence of missing plugins.txt (not installed at expected path) with assertion

- **setup.py:** Remove plugins.text as data_file and instead install with package data.  This is intended to harmonize install location across python distributions.  This also allows pkg_resources to retrieve the file based on the actual install location.

- **fopenx.c:** Send decompression filename as raw string as a means of handling spaces and special characters.